### PR TITLE
Add setting to enable sending buffering events

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -282,6 +282,7 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
     public static final String PREFERENCE_KEY_NOTIFICATION_CREATOR = "io.lbry.browser.preference.notifications.Creator";
     public static final String PREFERENCE_KEY_KEEP_SDK_BACKGROUND = "io.lbry.browser.preference.other.KeepSdkInBackground";
     public static final String PREFERENCE_KEY_PARTICIPATE_DATA_NETWORK = "io.lbry.browser.preference.other.ParticipateInDataNetwork";
+    public static final String PREFERENCE_KEY_SEND_BUFFERING_EVENTS = "io.lbry.browser.preference.other.SendBufferingEvents";
 
     // Internal flags / setting preferences
     public static final String PREFERENCE_KEY_INTERNAL_SKIP_WALLET_ACCOUNT = "io.lbry.browser.preference.internal.WalletSkipAccount";

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -294,7 +294,15 @@ public class FileViewFragment extends BaseFragment implements
                         loadingNewClaim = false;
                     }
                 } else if (playbackState == Player.STATE_BUFFERING) {
-                    if (MainActivity.appPlayer != null && MainActivity.appPlayer.getCurrentPosition() > 0) {
+                    Context ctx = getContext();
+                    boolean sendBufferingEvents = false;
+
+                    if (ctx != null) {
+                        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
+                        sendBufferingEvents = sp.getBoolean(MainActivity.PREFERENCE_KEY_SEND_BUFFERING_EVENTS, false);
+                    }
+
+                    if (MainActivity.appPlayer != null && MainActivity.appPlayer.getCurrentPosition() > 0 && sendBufferingEvents) {
                         // we only want to log a buffer event after the media has already started playing
                         String mediaSourceUrl = getStreamingUrl();
                         long duration = MainActivity.appPlayer.getDuration();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
 
     <string name="keep_sdk_in_background">Keep the LBRY service running in the background for improved wallet and network performance</string>
     <string name="participate_in_data_network">Participate in the data network (requires app and background service restart)</string>
+    <string name="send_buffering_events">Send buffering events to LBRY servers</string>
 
     <!-- URL suggestions -->
     <string name="search_url_title">%1$s - Search</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -58,5 +58,10 @@
             app:title="@string/participate_in_data_network"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
+        <SwitchPreferenceCompat
+            app:key="io.lbry.browser.preference.other.SendBufferingEvents"
+            app:title="@string/send_buffering_events"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 1

## What is the current behavior?
Buffering events are sent to LBRY without user permission. User cannot disable this behavior. This makes Tracking AntiFeature to appear in FDroid store listing.
## What is the new behavior?
No buffering event is sent to LBRY servers by default. User can enable this events to be sent at will. FDroid will not show the Tracking AntiFeature as user is in control of data being sent and the default is to not send it.
## Other information
I am creating this PR so it could be reviewed by another person different than mine -which could spot any potential new bug-. This PR has also been created here instead of upstream because the problem is about FDroid, so it seems more logical to make modifications here.

EDIT: translation on 1 new string will be required. Of course it could be reworded if LBRY teams requires it.

I will leave it as it is until reviewer accepts the modifications or LBRY team gives explicit consent to merge it. If a new tagged release appears in lbry-android and this hasn't been merged yet, I will request for permission to merge it.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
